### PR TITLE
Support setting static tags on local root spans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.py[cod]
 *.orig
 
+venv
+
 # pyenv
 .python-version
 

--- a/jaeger_client/__init__.py
+++ b/jaeger_client/__init__.py
@@ -26,7 +26,7 @@ sys.path.append(modpath.__path__[0])
 # w/ beta pre-release segment:
 # x.y.z.devA -> x.y.zbA.devB
 # Updated dev release (B) is for tracking changes against upstream version
-__version__ = '3.13.1b0.dev2'
+__version__ = '3.13.1b0.dev3'
 
 from .tracer import Tracer  # noqa
 from .config import Config  # noqa

--- a/jaeger_client/config.py
+++ b/jaeger_client/config.py
@@ -115,12 +115,14 @@ class Config(object):
             metrics=Metrics(),
             logger=logger if self.logging else None,
         )
+        self._root_span_tags = config.get('root_span_tags', {})
 
     def _validate_config(self, config):
         allowed_keys = ['logging',
                         'local_agent',
                         'sampler',
                         'tags',
+                        'root_span_tags',
                         'enabled',
                         'reporter_batch_size',
                         'reporter_queue_size',
@@ -460,6 +462,7 @@ class Config(object):
             baggage_header_prefix=self.baggage_header_prefix,
             debug_id_header=self.debug_id_header,
             tags=self.tags,
+            root_span_tags=self._root_span_tags,
             max_tag_value_length=self.max_tag_value_length,
             extra_codecs=self.propagation,
             throttler=throttler,

--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -54,6 +54,7 @@ class Tracer(opentracing.Tracer):
         max_tag_value_length=constants.MAX_TAG_VALUE_LENGTH,
         throttler=None,
         scope_manager=None,
+        root_span_tags=None,
     ):
         self.service_name = service_name
         self.reporter = reporter
@@ -66,6 +67,7 @@ class Tracer(opentracing.Tracer):
         self.max_tag_value_length = max_tag_value_length
         self.max_trace_id_bits = constants._max_trace_id_bits if generate_128bit_trace_id \
             else constants._max_id_bits
+        self.root_span_tags = root_span_tags
         self.codecs = {
             Format.TEXT_MAP: TextCodec(
                 url_encoding=False,
@@ -147,6 +149,11 @@ class Tracer(opentracing.Tracer):
 
         if self.active_span is not None and not ignore_active_span:
             parent = self.active_span
+
+        tags = tags or {}
+        is_local_root = not parent or isinstance(parent, SpanContext)
+        if is_local_root and self.root_span_tags:
+            tags.update(self.root_span_tags)
 
         if references:
             if isinstance(references, list):


### PR DESCRIPTION
Added root_span_tags tracer/config option

`root_span_tags` config/tracer option works just like the `tags` option but only adds the tags to the local root spans.

Any spans that either don't have a parent or use span context instead of a span instance as the parent are consider local root spans.