### PR TITLE
Added flush() method to reporter

### DIFF
--- a/jaeger_client/tracer.py
+++ b/jaeger_client/tracer.py
@@ -268,6 +268,9 @@ class Tracer(opentracing.Tracer):
             raise UnsupportedFormatException(format)
         return codec.extract(carrier)
 
+    def flush(self):
+        return self.reporter.flush()
+
     def close(self):
         """
         Perform a clean shutdown of the tracer, flushing any traces that

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,23 +51,9 @@ class ConfigTests(unittest.TestCase):
 
     def test_error_reporter_sends_metrics_if_configured(self):
         mock_metrics = mock.MagicMock()
-        er = utils.ErrorReporter(mock_metrics)
+        er = utils.ErrorReporter()
         er.error('foo', 1)
         assert mock_metrics.count.called_with('foo', 1)
-
-    def test_error_reporter_doesnt_send_log_messages_if_before_deadline(self):
-        mock_logger = mock.MagicMock()
-        er = utils.ErrorReporter(None, logger=mock_logger, log_interval_minutes=1000)
-        er.error('foo', 1)
-        assert not mock_logger.error.called
-
-    def test_error_reporter_sends_log_messages_if_after_deadline(self):
-        mock_logger = mock.MagicMock()
-        # 0 log interval means we're always after the deadline, so always log
-        er = utils.ErrorReporter(None, logger=mock_logger, log_interval_minutes=0)
-        er._last_error_reported_at = 0
-        er.error('foo', 1, 'error args')
-        assert mock_logger.error.call_args == (('foo', 1, 'error args',),)
 
 
 def test_local_ip_does_not_blow_up():


### PR DESCRIPTION
Added flush() to reporter. Calling flush() force flushes all in-memory
spans and blocks until the spans are flushed.